### PR TITLE
Fixed a bug in pebble-js-app.js/startTimer

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -17,10 +17,9 @@
     "resources": {
         "media": [
             {
-                "file": "images/toggl.png",
-                "menuIcon": true,
-                "name": "ICON_MENU",
-                "type": "png"
+                "file": "images/start.png",
+                "name": "ICON_START",
+                "type": "png-trans"
             },
             {
                 "file": "images/stop.png",
@@ -28,15 +27,17 @@
                 "type": "png-trans"
             },
             {
-                "file": "images/start.png",
-                "name": "ICON_START",
-                "type": "png-trans"
+                "file": "images/toggl.png",
+                "menuIcon": true,
+                "name": "ICON_MENU",
+                "type": "png"
             }
         ]
     },
+    "sdkVersion": "2",
     "shortName": "ToggleApp",
     "uuid": "5354f8f8-db7b-4f71-8eff-bc9cfb927884",
-    "versionCode": 3,
+    "versionCode": 1,
     "versionLabel": "1.2",
     "watchapp": {
         "watchface": false

--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -29,6 +29,7 @@ function startTimer() {
 	var data = {};
 	data.time_entry = {};
     data.time_entry.description = localStorage.getItem("desc");
+    data.time_entry.created_with = "TogglAppPebble";
     var json = JSON.stringify(data);
     var result = send(token,"POST","time_entries/start",json);
     return result.data;


### PR DESCRIPTION
toggl.com/api/v8/time_entries/start needs "created_with" key

I bought Pebble yesterday and TogglAppPebble didn't work well.
I coudn't start a timer from Pebble.

I compile your app and I found that Toggl api respond error.

```
[PHONE] pebble-app.js:?: ToggleApp__1.0/pebble-js-app.js:86 Received message: [object Object]
[PHONE] pebble-app.js:?: ToggleApp__1.0/pebble-js-app.js:9 Send token[my api key]
[PHONE] pebble-app.js:?: ToggleApp__1.0/pebble-js-app.js:11 Basic [encoded key:api_token]
[PHONE] pebble-app.js:?: ToggleApp__1.0/pebble-js-app.js:19 400
[PHONE] pebble-app.js:?: ToggleApp__1.0/pebble-js-app.js:20 created_with needs to be provided an a valid string
```

The api(toggl.com/api/v8/time_entries/start) needs created_with key.
So I add data of that.

I'm sorry for my bad English.
Thank you.
