### PR TITLE
Fixed timer start (again). Updated to SDK 3, added some color.

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -17,12 +17,6 @@
     "resources": {
         "media": [
             {
-                "file": "images/toggl.png",
-                "menuIcon": true,
-                "name": "ICON_MENU",
-                "type": "png"
-            },
-            {
                 "file": "images/stop.png",
                 "name": "ICON_STOP",
                 "type": "png-trans"
@@ -31,13 +25,23 @@
                 "file": "images/start.png",
                 "name": "ICON_START",
                 "type": "png-trans"
+            },
+            {
+                "file": "images/toggl.png",
+                "menuIcon": true,
+                "name": "ICON_MENU",
+                "type": "png"
             }
         ]
     },
+    "sdkVersion": "3",
     "shortName": "ToggleApp",
+    "targetPlatforms": [
+        "aplite",
+        "basalt"
+    ],
     "uuid": "5354f8f8-db7b-4f71-8eff-bc9cfb927884",
-    "versionCode": 3,
-    "versionLabel": "1.2",
+    "versionLabel": "1.21",
     "watchapp": {
         "watchface": false
     }

--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -26,9 +26,11 @@ function send(token,method,call,json) {
 }
 
 function startTimer() {
-	var data = {};
-	data.time_entry = {};
+    var data = {};
+    data.time_entry = {};
     data.time_entry.description = localStorage.getItem("desc");
+    data.time_entry.created_with = "TogglAppPebble";
+    
     var json = JSON.stringify(data);
     var result = send(token,"POST","time_entries/start",json);
     return result.data;

--- a/src/main.c
+++ b/src/main.c
@@ -127,11 +127,17 @@ void start_click_config_provider(void *context) {
 void my_window_load(Window *window) {
 	Layer *window_layer = window_get_root_layer(window);
 	GRect bounds = layer_get_frame(window_layer);
-	GRect content_layer_bounds = GRect(3,bounds.origin.y+TITLE_HEIGHT,bounds.size.w-ACTION_BAR_WIDTH-10-3,bounds.size.h-TITLE_HEIGHT+10);
+	GRect content_layer_bounds = GRect(2,bounds.origin.y+TITLE_HEIGHT,bounds.size.w-ACTION_BAR_WIDTH-3,bounds.size.h-TITLE_HEIGHT+10);
 	
-	title_layer = text_layer_create(GRect(0,0,bounds.size.w-ACTION_BAR_WIDTH-10,TITLE_HEIGHT));
-	text_layer_set_background_color(title_layer, GColorWhite);
+	title_layer = text_layer_create(GRect(0,0,bounds.size.w-ACTION_BAR_WIDTH,TITLE_HEIGHT));
+#ifdef PBL_COLOR
+  text_layer_set_background_color(title_layer, GColorDarkCandyAppleRed);
+	text_layer_set_text_color(title_layer, GColorWhite);
+#else
+  text_layer_set_background_color(title_layer, GColorWhite);
 	text_layer_set_text_color(title_layer, GColorBlack);
+#endif
+  
 	text_layer_set_text_alignment(title_layer, GTextAlignmentCenter);
 	text_layer_set_font(title_layer, fonts_get_system_font(FONT_KEY_BITHAM_42_LIGHT));
 	text_layer_set_text(title_layer, "Toggl");
@@ -141,7 +147,7 @@ void my_window_load(Window *window) {
 	text_layer_set_text_color(content_layer, GColorBlack);
 	text_layer_set_text_alignment(content_layer, GTextAlignmentCenter);
 	text_layer_set_font(content_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
-	text_layer_set_text(content_layer, "time to Toggl!");
+	text_layer_set_text(content_layer, "Configure to start!");
 	
 	icon_start = gbitmap_create_with_resource (RESOURCE_ID_ICON_START_BLACK);
     icon_stop = gbitmap_create_with_resource (RESOURCE_ID_ICON_STOP_BLACK);


### PR DESCRIPTION
This pull requests fixes timer starting again, by adding a 'created_with' json field. It also upgrades SDK to v3, and makes the app logo white on read (as on toggl website).

Printing time/date is broken (negatives and big numbers), but the toggled timer works fine despite wrong screen outputs.
